### PR TITLE
Focus Bug Report

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1033,6 +1033,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7ffc5c5338469d4d3ea17d269fa8ea3512ad247247c30bd2df69e68309ed0a08"
 
 [[package]]
+name = "maybe-uninit"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "60302e4db3a61da70c0cb7991976248362f30319e88850c487b9b95bbf059e00"
+
+[[package]]
 name = "memchr"
 version = "2.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1059,6 +1065,12 @@ checksum = "b9f1c5b025cda876f66ef43a113f91ebc9f4ccef34843000e0adf6ebbab84e21"
 dependencies = [
  "winapi",
 ]
+
+[[package]]
+name = "nameof"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba896fb4d7fe86433ebaf18c532bd9202e54c450a1bf7723855220e0e76d71d1"
 
 [[package]]
 name = "ndk"
@@ -1540,11 +1552,11 @@ dependencies = [
 [[package]]
 name = "tao"
 version = "0.2.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ece0608233e93504778f4740457cdd3508966a691de8cedbbc7291f80236250"
+source = "git+https://github.com/tauri-apps/tao?rev=d1065e3d9e4f0f48b366ce9736a57b5866c003db#d1065e3d9e4f0f48b366ce9736a57b5866c003db"
 dependencies = [
  "bitflags",
  "cairo-rs",
+ "cc",
  "cocoa 0.24.0",
  "core-foundation 0.9.1",
  "core-graphics 0.22.2",
@@ -1552,14 +1564,17 @@ dependencies = [
  "dispatch",
  "gdk",
  "gdk-pixbuf",
+ "gdk-sys",
  "gio",
  "glib",
+ "glib-sys",
  "gtk",
  "instant",
  "lazy_static",
  "libappindicator",
  "libc",
  "log",
+ "nameof",
  "ndk",
  "ndk-glue",
  "ndk-sys",
@@ -1569,7 +1584,9 @@ dependencies = [
  "scopeguard",
  "serde",
  "sourceview",
+ "unicode-segmentation",
  "winapi",
+ "x11-dl",
 ]
 
 [[package]]
@@ -1859,7 +1876,7 @@ checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 [[package]]
 name = "wry"
 version = "0.9.4"
-source = "git+https://github.com/tauri-apps/wry?rev=81f3218d9ac55a987b050f574774afcaa0b5c2f7#81f3218d9ac55a987b050f574774afcaa0b5c2f7"
+source = "git+https://github.com/tauri-apps/wry?rev=761b2b59fe0434b3458d99ed599394af0e1e3962#761b2b59fe0434b3458d99ed599394af0e1e3962"
 dependencies = [
  "cocoa 0.24.0",
  "core-graphics 0.22.2",
@@ -1883,4 +1900,16 @@ dependencies = [
  "webview2",
  "webview2-sys",
  "winapi",
+]
+
+[[package]]
+name = "x11-dl"
+version = "2.18.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2bf981e3a5b3301209754218f962052d4d9ee97e478f4d26d4a6eced34c1fef8"
+dependencies = [
+ "lazy_static",
+ "libc",
+ "maybe-uninit",
+ "pkg-config",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,3 +4,6 @@ members = [
   "lyra",
   "keys",
 ]
+
+[patch.crates-io]
+tao = { git = "https://github.com/tauri-apps/tao", rev = "d1065e3d9e4f0f48b366ce9736a57b5866c003db" }

--- a/lyra/Cargo.toml
+++ b/lyra/Cargo.toml
@@ -12,4 +12,4 @@ serde = "1.0.123"
 serde_json = "1.0.64"
 thiserror = "1.0.24"
 tokio = { version = "1.2.0", features = ["full"] }
-wry = {git = "https://github.com/tauri-apps/wry", rev = "81f3218d9ac55a987b050f574774afcaa0b5c2f7"}
+wry = {git = "https://github.com/tauri-apps/wry", rev = "761b2b59fe0434b3458d99ed599394af0e1e3962"}

--- a/lyra/src/main.rs
+++ b/lyra/src/main.rs
@@ -14,7 +14,6 @@ use event::Event as UserEvent;
 use wry::application::{
   event::{Event, StartCause, WindowEvent},
   event_loop::ControlFlow,
-  menu::MenuType,
 };
 
 #[tokio::main]
@@ -49,14 +48,6 @@ async fn main() {
         ..
       } => {
         webview.window().set_visible(false);
-      }
-      Event::MenuEvent {
-        origin: MenuType::SystemTray,
-        ..
-      } => {
-        // TODO can do something; but you'll need the menu_id generated from the MenuItem
-        //      to operate on specific options within the Tray. Perhaps pass a lookup from
-        //      from the window creation process
       }
       Event::WindowEvent {
         event: WindowEvent::CloseRequested,

--- a/lyra/src/window.rs
+++ b/lyra/src/window.rs
@@ -6,7 +6,7 @@ use wry::{
     dpi::{LogicalPosition, LogicalSize},
     event_loop::EventLoop,
     menu::MenuItem,
-    platform::system_tray::SystemTrayBuilder,
+    system_tray::SystemTrayBuilder,
     window::WindowBuilder,
   },
   webview::{WebView, WebViewBuilder},
@@ -51,7 +51,7 @@ pub fn configure() -> Result<(EventLoop<Event>, WebView), wry::Error> {
         })
     })
     .with_url("lyra://index.html")?
-    .build()?;
+    .build(&Default::default())?;
 
   #[cfg(target_os = "windows")]
   let icon_data = BUNDLE_DIR
@@ -73,8 +73,7 @@ pub fn configure() -> Result<(EventLoop<Event>, WebView), wry::Error> {
     eprintln!("Failed to pull resource: {:?}", e);
     wry::Error::InitScriptError
   })?;
-  let open_new_window = MenuItem::new("Lyra");
-  let _system_tray = SystemTrayBuilder::new(icon, vec![open_new_window]).build(&evloop)?;
+  let _system_tray = SystemTrayBuilder::new(icon, None).build(&evloop)?;
 
   Ok((evloop, _webview))
 }


### PR DESCRIPTION
While working on #5 / #10 i noticed focus was getting lost after the window was hidden then reshown (`set_visible(false)`). When I checked out master again the bug did not produce, indicating it was something on my branch. I created this PR/branch to minimize the changes to create the issue - which appears to just be bumping wry/tao version.

Effectively, it looks like: https://github.com/tauri-apps/wry/issues/184

## Reproducing

- Check out this branch
- `cargo run` (You'll need yarn to get the resources to build, sorry 😬 )
- Open the window (`cmd+space`), notice you have focus
- Click out the window (which triggers the `set_focus(false)` in the event loop)
- Open the window (`cmd+space`) again, but notice focus isn't on it anymore.

## WRY Version
I was already on a relatively new version, and the diff shows that: https://github.com/tauri-apps/wry/compare/81f3218d9ac55a987b050f574774afcaa0b5c2f7..761b2b59fe0434b3458d99ed599394af0e1e3962

The only meaningful change was in WebContext, which doesn't really sound like a source of the problem

## TAO Version

Conversely, Wry is currently pinned to `0.2.6` of TAO; whereas my PR had to pin to a newer version to get the keyboard/system tray improvements. When we compare that diff, it's much larger: https://github.com/tauri-apps/tao/compare/afd1316a7e0289ec34fb49f12ccfb5e3c1387b7b..d1065e3d9e4f0f48b366ce9736a57b5866c003db

What stands out: [there were focus changes](https://github.com/tauri-apps/tao/compare/afd1316a7e0289ec34fb49f12ccfb5e3c1387b7b..d1065e3d9e4f0f48b366ce9736a57b5866c003db#diff-9c3e23a9e927925ded60e421b1640fafd593a88a71c15999468c79653cc4ffac) which appear to have added [this logic](https://github.com/tauri-apps/tao/compare/afd1316a7e0289ec34fb49f12ccfb5e3c1387b7b..d1065e3d9e4f0f48b366ce9736a57b5866c003db#diff-4803bb2335a17d700335730b9f62828e001faa602b9b894dff572422c737b78a)